### PR TITLE
Added graphs for query and monitor command

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tabulate~=0.8.10
 python-dateutil~=2.8.2
 pytimeparse~=1.1.8
 pprintpp~=0.4.0
+plotext~=5.2.7

--- a/sdk/meta_query_gui.py
+++ b/sdk/meta_query_gui.py
@@ -261,14 +261,14 @@ class QueryGui:
     # Used to keep track of total sent and the throughput achieved by summing the bytes sent and total time from startime to lastUpdated.
     # This is another interpretation of throughput. Then we can print the final throughput at the end of the job.
     def pretty_print_influx_data(self, measurement_data_list):
-        influx_cols_select = ['jobId', 'throughput', 'concurrency', 'parallelism', 'dataBytesSent',
-                              'pipelining']
+        influx_cols_select = ['throughput', 'concurrency', 'parallelism', 'dataBytesSent',
+                              'pipelining', 'rtt', 'dropin', 'dropout']
         influx_df = pd.DataFrame.from_records(measurement_data_list)
-        pd.set_option('display.max_columns', None)
-        print(influx_df.head())
         for col in influx_cols_select:
             if col not in influx_df:
                 influx_df[col] = np.nan
+        if len(measurement_data_list) > 0:
+            print('Job Id: ', measurement_data_list[0]['jobId'])
         print(influx_df[influx_cols_select].to_string())
 
         if self.influx_df.empty:
@@ -313,9 +313,10 @@ class QueryGui:
         plt.subplots(2, 1)
 
         plt.subplot(1, 1).plot_size(2*plt.tw()/3, plt.th()/3)
-        plt.subplot(1, 1).plot(time, influx_df['throughput'])
-        plt.subplot(1, 1).xlabel("Time")
-        plt.subplot(1, 1).ylabel("Throughput")
+        y = [x/1e6 for x in influx_df['throughput']]
+        plt.subplot(1, 1).plot(time, y)
+        plt.subplot(1, 1).xlabel("Time(s)")
+        plt.subplot(1, 1).ylabel("Throughput(Mbps)")
         plt.subplot(1, 1).xticks(time_labels)
         plt.subplot(1, 1).title("Throughput Plot")
 
@@ -323,6 +324,6 @@ class QueryGui:
         plt.subplot(2, 1).plot(influx_df['parallelism'], label = "Parallelism")
         plt.subplot(2, 1).plot(influx_df['concurrency'], label = "Concurrency")
         plt.subplot(2, 1).plot(influx_df['pipelining'], label = "Pipelining")
-        plt.subplot(2, 1).xlabel("Time")
+        plt.subplot(2, 1).xlabel("Time(s)")
         plt.subplot(2, 1).xticks(time_labels)
         plt.show()

--- a/sdk/meta_query_gui.py
+++ b/sdk/meta_query_gui.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pprint
 import csv
 from sdk.log import Log
+import plotext as plt
 # STARTING, STARTED, STOPPING,
 # STOPPED, FAILED, COMPLETED, ABANDONED
 
@@ -263,10 +264,13 @@ class QueryGui:
         influx_cols_select = ['jobId', 'throughput', 'concurrency', 'parallelism', 'dataBytesSent',
                               'pipelining']
         influx_df = pd.DataFrame.from_records(measurement_data_list)
+        pd.set_option('display.max_columns', None)
+        print(influx_df.head())
         for col in influx_cols_select:
             if col not in influx_df:
                 influx_df[col] = np.nan
         print(influx_df[influx_cols_select].to_string())
+
         if self.influx_df.empty:
             self.influx_df = influx_df
         else:
@@ -288,6 +292,8 @@ class QueryGui:
               ' bits/second', ' Parsed throughput: ', ((avg_throughput / 1000000) * 8), 'Mbps')
         print("Time remaining: ", remainingTime)
 
+        self.plot_graphs(influx_df)
+
     def print_finished_job(self):
         print('Job Completed with values')
 
@@ -299,3 +305,24 @@ class QueryGui:
         if 'lastUpdated' in df.columns:
             df['lastUpdated'] = pd.to_datetime(df['lastUpdated'])
         return df
+
+    def plot_graphs(self, influx_df):
+        print("\n")
+        time = [x for x in range(influx_df.shape[0])]
+        time_labels = [x for x in range(0, influx_df.shape[0], 3)]
+        plt.subplots(2, 1)
+
+        plt.subplot(1, 1).plot_size(2*plt.tw()/3, plt.th()/3)
+        plt.subplot(1, 1).plot(time, influx_df['throughput'])
+        plt.subplot(1, 1).xlabel("Time")
+        plt.subplot(1, 1).ylabel("Throughput")
+        plt.subplot(1, 1).xticks(time_labels)
+        plt.subplot(1, 1).title("Throughput Plot")
+
+        plt.subplot(2, 1).plot_size(2*plt.tw()/3, plt.th()/3)
+        plt.subplot(2, 1).plot(influx_df['parallelism'], label = "Parallelism")
+        plt.subplot(2, 1).plot(influx_df['concurrency'], label = "Concurrency")
+        plt.subplot(2, 1).plot(influx_df['pipelining'], label = "Pipelining")
+        plt.subplot(2, 1).xlabel("Time")
+        plt.subplot(2, 1).xticks(time_labels)
+        plt.show()


### PR DESCRIPTION
Added 2 graphs:

1. Display the throughput throughout different influx points
2. Display the concurrency, parallelism, pipelining throughout different influx points.

<img width="971" alt="image" src="https://user-images.githubusercontent.com/41269787/194941953-1c738a7d-6cf8-4915-803b-4805eace87f3.png">

Example for images of graphs.